### PR TITLE
BUG: fix jit when numba not installed

### DIFF
--- a/src/bayesbeat/model/generic_analytic.py
+++ b/src/bayesbeat/model/generic_analytic.py
@@ -27,7 +27,7 @@ except ImportError:
     # Based on https://stackoverflow.com/a/73275170
     def jit(f=None, *args, **kwargs):
         def decorator(func):
-            return func 
+            return func
 
         if callable(f):
             return f

--- a/src/bayesbeat/model/generic_analytic.py
+++ b/src/bayesbeat/model/generic_analytic.py
@@ -24,8 +24,15 @@ try:
 except ImportError:
     warn("Could not import numba", RuntimeWarning)
 
-    def jit(*args, **kwargs):
-        return lambda f: f
+    # Based on https://stackoverflow.com/a/73275170
+    def jit(f=None, *args, **kwargs):
+        def decorator(func):
+            return func 
+
+        if callable(f):
+            return f
+        else:
+            return decorator
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fix the `jit` function that is used if `numba` is not installed.

Closes https://github.com/mj-will/bayesbeat/issues/11

@jcbayley let me know if this fixes the issue you had.